### PR TITLE
🐛 修复 get_message_id 被弃用的问题并简单修缮了代码格式

### DIFF
--- a/nonebot_plugin_marshoai/dev.py
+++ b/nonebot_plugin_marshoai/dev.py
@@ -114,30 +114,38 @@ async def call_function(
     recursive=True,
 )
 def on_plugin_file_change(event):
-    if event.src_path.endswith(".py"):
-        logger.info(f"文件变动: {event.src_path}")
-        # 层层向上查找到插件目录
-        dir_list: list[str] = event.src_path.split("/")  # type: ignore
-        dir_list[-1] = dir_list[-1].split(".", 1)[0]
-        dir_list.reverse()
-        for plugin_name in dir_list:
-            if plugin := get_plugin(plugin_name):
-                if plugin.module_path.endswith("__init__.py"):
-                    # 包插件
-                    if os.path.dirname(plugin.module_path).replace(
-                        "\\", "/"
-                    ) in event.src_path.replace("\\", "/"):
-                        logger.debug(f"找到变动插件: {plugin.name}，正在重新加载")
-                        reload_plugin(plugin)
-                        context.reset_all()
-                        break
-                else:
-                    # 单文件插件
-                    if plugin.module_path == event.src_path:
-                        logger.debug(f"找到变动插件: {plugin.name}，正在重新加载")
-                        reload_plugin(plugin)
-                        context.reset_all()
-                        break
+    if not event.src_path.endswith(".py"):
+        return
+
+    logger.info(f"文件变动: {event.src_path}")
+    # 层层向上查找到插件目录
+    dir_list: list[str] = event.src_path.split("/")  # type: ignore
+    dir_list[-1] = dir_list[-1].split(".", 1)[0]
+    dir_list.reverse()
+
+    for plugin_name in dir_list:
+        if not (plugin := get_plugin(plugin_name)):
+            continue
+
+        if (
+            plugin.module_path
+            and plugin.module_path.endswith("__init__.py")
+            and os.path.dirname(plugin.module_path).replace("\\", "/")
+            in event.src_path.replace("\\", "/")
+        ):  # 包插件
+            logger.debug(f"找到变动插件: {plugin.name}，正在重新加载")
+            reload_plugin(plugin)
+            context.reset_all()
+            break
         else:
-            logger.debug("未找到变动插件")
-            return
+            # 单文件插件
+            if plugin.module_path != event.src_path:
+                continue
+
+            logger.debug(f"找到变动插件: {plugin.name}，正在重新加载")
+            reload_plugin(plugin)
+            context.reset_all()
+            break
+    else:
+        logger.debug("未找到变动插件")
+        return

--- a/nonebot_plugin_marshoai/handler.py
+++ b/nonebot_plugin_marshoai/handler.py
@@ -22,6 +22,7 @@ from nonebot_plugin_alconna.uniseg import (
     Text,
     UniMessage,
     UniMsg,
+    get_message_id,
     get_target,
 )
 from nonebot_plugin_argot import Argot  # type: ignore
@@ -57,7 +58,7 @@ class MarshoHandler:
         self.event: Event = current_event.get()
         # self.state: T_State = current_handler.get().state
         self.matcher: Matcher = current_matcher.get()
-        self.message_id: str = UniMessage.get_message_id(self.event)
+        self.message_id: str = get_message_id(self.event)
         self.target = get_target(self.event)
 
     async def process_user_input(

--- a/nonebot_plugin_marshoai/handler.py
+++ b/nonebot_plugin_marshoai/handler.py
@@ -125,7 +125,7 @@ class MarshoHandler:
 
     async def handle_function_call(
         self,
-        completion: Union[ChatCompletion],
+        completion: Union[ChatCompletion, AsyncStream[ChatCompletionChunk]],
         user_message: Union[str, list],
         model_name: str,
         tools_list: list | None = None,
@@ -249,7 +249,7 @@ class MarshoHandler:
                     Text(await process_completion_to_details(response)),
                     command="detail",
                     expired_at=timedelta(minutes=5),
-                )
+                )  # type:ignore
             )
             # send_message.append(
             #     Argot(

--- a/nonebot_plugin_marshoai/marsho.py
+++ b/nonebot_plugin_marshoai/marsho.py
@@ -121,7 +121,7 @@ async def add_assistantmsg(target: MsgTarget, arg: Message = CommandArg()):
 @praises_cmd.handle()
 async def praises():
     # await UniMessage(await tools.call("marshoai-weather.get_weather", {"location":"杭州"})).send()
-    await praises_cmd.finish(build_praises())
+    await praises_cmd.finish(await build_praises())
 
 
 @contexts_cmd.handle()

--- a/nonebot_plugin_marshoai/models.py
+++ b/nonebot_plugin_marshoai/models.py
@@ -116,7 +116,8 @@ class MarshoTools:
                 spec = importlib.util.spec_from_file_location(
                     package_name, os.path.join(package_path, "__init__.py")
                 )
-                assert spec, f"工具包 {package_name} 未找到"
+                if not spec:
+                    raise ImportError(f"工具包 {package_name} 未找到")
                 package = importlib.util.module_from_spec(spec)
                 self.imported_packages[package_name] = package
                 sys.modules[package_name] = package

--- a/nonebot_plugin_marshoai/models.py
+++ b/nonebot_plugin_marshoai/models.py
@@ -1,9 +1,8 @@
 import importlib
+import importlib.util
 import json
 import os
 import sys
-
-# import importlib.util
 import traceback
 
 from nonebot import logger
@@ -117,10 +116,11 @@ class MarshoTools:
                 spec = importlib.util.spec_from_file_location(
                     package_name, os.path.join(package_path, "__init__.py")
                 )
+                assert spec, f"工具包 {package_name} 未找到"
                 package = importlib.util.module_from_spec(spec)
                 self.imported_packages[package_name] = package
                 sys.modules[package_name] = package
-                spec.loader.exec_module(package)
+                spec.loader.exec_module(package)  # type:ignore
 
                 logger.success(f"成功加载工具包 {package_name}")
             except json.JSONDecodeError as e:

--- a/nonebot_plugin_marshoai/observer.py
+++ b/nonebot_plugin_marshoai/observer.py
@@ -29,7 +29,7 @@ def debounce(wait):
         def wrapper(*args, **kwargs):
             nonlocal last_call_time
             current_time = time.time()
-            if (current_time - last_call_time) > wait:
+            if last_call_time is None or (current_time - last_call_time) > wait:
                 last_call_time = current_time
                 return func(*args, **kwargs)
 
@@ -52,7 +52,7 @@ class CodeModifiedHandler(FileSystemEventHandler):
     """
 
     @debounce(1)
-    def on_modified(self, event):
+    def on_modified(self, event: FileSystemEvent):
         raise NotImplementedError("on_modified must be implemented")
 
     def on_created(self, event):

--- a/nonebot_plugin_marshoai/utils/processor.py
+++ b/nonebot_plugin_marshoai/utils/processor.py
@@ -24,9 +24,9 @@ async def process_chat_stream(
             delta = chunk.choices[0].delta
             if (
                 hasattr(delta, "reasoning_content")
-                and delta.reasoning_content is not None
+                and delta.reasoning_content is not None  # type:ignore
             ):
-                reasoning_contents += delta.reasoning_content
+                reasoning_contents += delta.reasoning_content  # type:ignore
             else:
                 if not is_answering:
                     logger.info(

--- a/nonebot_plugin_marshoai/utils/processor.py
+++ b/nonebot_plugin_marshoai/utils/processor.py
@@ -72,6 +72,9 @@ async def process_chat_stream(
 
 
 async def process_completion_to_details(completion: ChatCompletion) -> str:
+    if not isinstance(completion, ChatCompletion):
+        return "暂不支持对流式调用用量的获取，或预期之外的输入"
+
     usage_text = ""
     usage = completion.usage
     if usage is None:


### PR DESCRIPTION
主要更新：
- 修复 get_message_id 被弃用的问题 https://github.com/LiteyukiStudio/nonebot-plugin-marshoai/issues/31
- 初步修缮了根目录下的代码格式（留意到 [`process_completion_to_details`](https://github.com/LiteyukiStudio/nonebot-plugin-marshoai/blob/a18d85d45c4b4cd8ff5d5484304e46726bf09907/nonebot_plugin_marshoai/handler.py#L248C1-L249C1) 并不支持流式调用的用量获取，这可能需要对流程做一定改动，因此此处未作任何更改）

<details>
<summary>好饿哦</summary>
呐呐，陪我出去玩好不好
</details>

## Summary by Sourcery

Fix deprecated API usage and improve code robustness and formatting

Bug Fixes:
- Replace deprecated UniMessage.get_message_id call with get_message_id
- Add missing await for build_praises to correctly handle async result
- Add guard in process_completion_to_details to handle non-ChatCompletion inputs
- Fix debounce decorator to allow initial invocation

Enhancements:
- Refactor on_plugin_file_change for clearer early-return logic
- Add assertions and type annotations to improve type safety and suppress errors
- Apply minor formatting and type-ignore adjustments across modules